### PR TITLE
Add support for group chats, improve usability for large conversations

### DIFF
--- a/select_msg_from_roomname.sql
+++ b/select_msg_from_roomname.sql
@@ -1,0 +1,29 @@
+SELECT 
+    m.rowid as RowID,
+    h.id AS UniqueID, 
+    m.is_from_me as Is_From_Me,
+
+    CASE WHEN date > 0 THEN
+        time(date / 1000000000 + 978307200, 'unixepoch', 'localtime')
+        ELSE NULL
+    END AS Time,
+    
+    CASE WHEN date > 0 THEN
+        strftime('%Y%m%d', date / 1000000000 + 978307200, 'unixepoch', 'localtime')
+    END AS Date,
+
+    CASE WHEN date > 0 THEN
+        date / 1000000000 + 978307200
+    END AS Epoch,
+
+    text as Text,
+    a.filename AS AttachmentPath
+
+    FROM message m
+    LEFT JOIN handle h ON h.rowid = m.handle_id
+    LEFT JOIN message_attachment_join maj ON maj.message_id = m.rowid
+    LEFT JOIN attachment a ON a.rowid = maj.attachment_id
+
+    WHERE $whereclause
+
+    ORDER BY Date, Time

--- a/template/messages.html
+++ b/template/messages.html
@@ -3,6 +3,7 @@
 <html>
 <head>
     <title>iMessage Backup</title>
+    <meta charset="utf-8">
     <link rel="shortcut icon" href="img/heart.png"/>
     <link rel="stylesheet" href="messages.css">
     <script type="text/javascript" src="messages.js"></script>
@@ -59,6 +60,28 @@
                     </date>
                 </div>
                 <!--template:media-fromThem-end-->
+
+                <!--template:media-video-myMessage-start-->
+                <div class="message myMessage">
+                    <video controls>
+                        <source src="$media_path" type="$mime"/>
+                    </video>
+                    <date>
+                        <b>$name</b> $date $time
+                    </date>
+                </div>
+                <!--template:media-video-myMessage-end-->
+                
+                <!--template:media-video-fromThem-start-->
+                 <div class="message fromThem">
+                    <video controls>
+                        <source src="$media_path" type="$mime"/>
+                    </video>
+                    <date>
+                        <b>$name</b> $date $time
+                    </date>
+                </div>
+                <!--template:media-video-fromThem-end-->
                 
                 <div class="message fromThem">
                     <p>It This one is just a lot more text so hopefully it induces some wrapping or something of note to see, not really sure what will happen but I hope that it is interesting regardless beautiful!</p>


### PR DESCRIPTION
Group chat support:

- Additional SQL file uses the new date format. I haven't updated the other SQL files to use the same because it will probably break functionality for older backups.

Usability:

- The group chat I tested it on is huge, with ~ 20GB of photos and videos: when I tried to open it, it ran out of memory
- It now splits up the messages into a new file (e.g.`messages 10.html`) every 1000 messages

Videos:

- MP4s (and MOVs, although they can't actually be played on browsers at this point in time) now use the `video` tag instead of as an image
  - `.PLUGINPAYLOAD files` are still rendered as images though. I have no idea what they are

Bug fixes:

- If attachments have the same name, the attachment name is changed (e.g. `FullSizeRender.jpg` becomes `FullSizeRender (10).jpg`) instead of being overwritten

Other:

- Added a script which converts HEIC and MOV files into JPG and MP4
  files that can be viewed on browsers, and updates the URLs in the
  generated HTML files. Linux only unfortunately